### PR TITLE
finally ttl is working

### DIFF
--- a/url-shortener/handlers/get_long_url.py
+++ b/url-shortener/handlers/get_long_url.py
@@ -1,5 +1,6 @@
 import os
 import json
+import time
 import boto3
 
 dynamodb_client = boto3.client("dynamodb")
@@ -14,6 +15,15 @@ def redirect_to_long_url(event, context):
     result = dynamodb_client.get_item(
         TableName=TABLE_NAME,
         Key={"url_id": {"S": url_id}}).get("Item")
+
+    exp_date = result.get("ttl").get("N")
+    print(f'Я ТУТ {exp_date}')
+
+    if int(exp_date) < int(time.time()):
+        return {
+            "statusCode": 400,
+            "body": json.dumps({"error": "link expired"})
+        }
 
     if not result:
         return {


### PR DESCRIPTION
From beginning, I thought that dynamodb will remove items automatically from table during the time specified in the code, but that is not how it worked.

From https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/howitworks-ttl.html :
> TTL typically deletes expired items within 48 hours of expiration. Items that have expired, but haven’t yet been deleted by TTL, still appear in reads, queries, and scans. If you do not want expired items in the result set, you must filter them out.

It wasn't obvious to me, so I sat there wondering why the code didn't work. 
